### PR TITLE
write changeLogForRelease to home folder

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,11 +1,15 @@
 name: build Debian Live image
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths:
       - "debian-live/build.env"
       - "debian-live/build.sh"
       - "debian-live/config/**"
   pull_request:
+    branches-ignore:
+      - 'main'
     paths:
       - "debian-live/build.env"
       - "debian-live/build.sh"
@@ -44,7 +48,7 @@ jobs:
         with:
           name: iksdp-desktop-${{ env.RELEASE_VERSION }}
           artifacts: "~/build/debian-live-${{ env.DEBIAN_VERSION }}-${{ env.RELEASE_VERSION }}-${{ env.IMAGE_TIMESTAMP }}-${{ env.DEBIAN_ARCH }}.hybrid.iso"
-          bodyFile: "changeLogForRelease.md"
+          bodyFile: "~/changeLogForRelease.md"
           tag: ${{ env.RELEASE_VERSION }}
           draft: true
           makeLatest: "legacy"

--- a/debian-live/build.sh
+++ b/debian-live/build.sh
@@ -261,7 +261,7 @@ function installPrerequisites {
 function createChangeLogForRelease {
   loginfo "${FUNCNAME[0]}" "Extract the change description for the release from the CHANGELOG.md"
 
-  grep --perl-regexp --null-data --only-matching "## v${RELEASE_VERSION}[\s\S]*?(?=\n.*?#.{2}|$)" "${WORK_DIR}"/CHANGELOG.md > changeLogForRelease.md
+  grep --perl-regexp --null-data --only-matching "## v${RELEASE_VERSION}[\s\S]*?(?=\n.*?#.{2}|$)" "${WORK_DIR}"/CHANGELOG.md > ~/changeLogForRelease.md
   if [ "$?" -ne 0 ]; then
     logerror "${FUNCNAME[0]}" "changelog query failed"
     exit 1


### PR DESCRIPTION
- to have a predictable path for the create release step
- `main` branch on the ignore list to avoid triggered jobs after merged PRs