### PR TITLE
add .gitignore for debian-live/Containerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+debian-live/Containerfile


### PR DESCRIPTION
Ignore Containerfile since it contains configuration specific to the user.