### PR TITLE
iterate over parent folders for the createFolder function

### DIFF
--- a/debian-live/build.sh
+++ b/debian-live/build.sh
@@ -739,17 +739,27 @@ function generateBom {
 
 function createFolder {
   if [ -n "${1}" ]; then
-  local folder
-  folder="${1}"
+    local foldernames rootfolder folderindex foldercount
+    IFS=/ read -ra foldernames <<< "${1}"
+    rootfolder=""
+    folderindex=1
+    foldercount=${#foldernames[@]}
 
-    if [ ! -d "${folder}" ]; then
-      mkdir -p "${folder}"
-      if [ "$?" -ne 0 ]; then
-        logerror "${FUNCNAME[0]}" "${folder} creation failed"
-        exit 1
+    for name in ${foldernames[@]}; do
+      (( folderindex++ ))
+      rootfolder="${rootfolder}/${name}"
+
+      if [ ! -d "${rootfolder}" ]; then
+        mkdir "${rootfolder}"
+        if [ "$?" -ne 0 ]; then
+          logerror "${FUNCNAME[0]}" "${rootfolder} creation failed"
+          exit 1
+        fi
+        if [ "${folderindex}" -eq "${foldercount}" ]; then
+          loginfo "${FUNCNAME[0]}" "${rootfolder} successfully created"
+        fi
       fi
-      loginfo "${FUNCNAME[0]}" "${folder} successfully created"
-    fi
+    done
   else
     logerror "${FUNCNAME[0]}" "folder name parameter is missing"
     exit 1


### PR DESCRIPTION
- to ensure that the complete folder hierachy can be created without using -p
- this will also catch errors caused by for instance read only file systems