### PR TITLE
ZRAM based swap and /tmp using tmpfs managed with systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * default configuration for Gnome and Gnome shell extensions for easier accessibility
 * added mode indicator
 * added possibility to boot luks encrypted persistent volumes
+* [ZRAM based](https://wiki.debian.org/ZRam) swap added
+* `/tmp` using tmpfs managed with systemd
+* `50%` for ZRAM swap and /tmp tmpfs
 
 ## v0.2.0
 

--- a/debian-live/config/hooks/normal/9050-configure-zram-swap.hook.chroot
+++ b/debian-live/config/hooks/normal/9050-configure-zram-swap.hook.chroot
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+echo -e "ALGO=zstd\nPERCENT=50" | tee -a /etc/default/zramswap

--- a/debian-live/config/hooks/normal/9051-manage-tmpfs-with-systemd.hook.chroot
+++ b/debian-live/config/hooks/normal/9051-manage-tmpfs-with-systemd.hook.chroot
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+sed --in-place 's|^tmpfs \/tmp nosuid,nodev 0 0|# tmpfs \/tmp nosuid,nodev 0 0|' /etc/fstab
+cp /usr/share/systemd/tmp.mount /etc/systemd/system/
+systemctl enable tmp.mount

--- a/debian-live/package.yaml
+++ b/debian-live/package.yaml
@@ -209,6 +209,9 @@ packages:
       cryptsetup-initramfs:
         enable: true
         name: cryptsetup-initramfs
+      zramtools:
+        enable: true
+        name: zram-tools
 
   github:
     enable: true


### PR DESCRIPTION
- [ZRAM based](https://wiki.debian.org/ZRam) swap added
- `/tmp` using tmpfs managed with systemd
- `50%` for ZRAM swap and /tmp tmpfs
- to avoid the `oom-kill` as much as possible without having to use the SSD for the swap and /tmp

## idle status after boot:
<img width="771" alt="grafik" src="https://github.com/user-attachments/assets/0f43b892-af4e-4f20-9674-59c3e14628e4" />

## busy system:
- Firefox and Chromium running the `Speedometer 3` benchmark
- VSCode and LibreOffice started
<img width="1557" alt="grafik" src="https://github.com/user-attachments/assets/c0487c58-3f97-4e9f-80a4-25bff8e019e8" />

<img width="905" alt="grafik" src="https://github.com/user-attachments/assets/34cedeb0-5eb7-4678-911b-3dfe8335ace2" />

## busy system with tmpfs used:
- Firefox and Chromium running the `Speedometer 3` benchmark
- VSCode and LibreOffice started
- 1GB file stored on `/tmp`
- the system is slow but still usable and no `oom-kill` has been triggered
<img width="1556" alt="grafik" src="https://github.com/user-attachments/assets/a6007dec-fc29-40ec-8b3e-cabe62b3ea3e" />

<img width="903" alt="grafik" src="https://github.com/user-attachments/assets/5cf1b907-9049-4650-95f8-514bf4691cb6" />

