### PR TITLE
added cryptsetup for luks

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/build-image.yml"
       - "debian-live/vendor/**"
       - "debian-live/package.yaml"
+      - "CHANGELOG.md"
 jobs:
   checkFileChanges:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -9,6 +9,7 @@ on:
       - "debian-live/config/**"
       - ".github/workflows/build-image.yml"
       - "debian-live/vendor/**"
+      - "debian-live/package.yaml"
 jobs:
   checkFileChanges:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * default configuration for Gnome and Gnome shell extensions for easier accessibility
 * added mode indicator
-* added posibility to boot luks encrypted persistent volumes
+* added possibility to boot luks encrypted persistent volumes
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * default configuration for Gnome and Gnome shell extensions for easier accessibility
 * added mode indicator
+* added posibility to boot luks encrypted persistent volumes
 
 ## v0.2.0
 

--- a/debian-live/build.sh
+++ b/debian-live/build.sh
@@ -96,7 +96,7 @@ function configImage {
   fi
 
   if [ "${DEBIAN_USER_PERSISTENCE}" == "true" ]; then
-    liveConfigOptions+=" persistence"
+    liveConfigOptions+=" persistence persistence-encryption=luks,none"
   else
     liveConfigOptions+=" nopersistence"
   fi

--- a/debian-live/package.yaml
+++ b/debian-live/package.yaml
@@ -203,6 +203,12 @@ packages:
       systemd-timesyncd:
         enable: true
         name: systemd-timesyncd
+      cryptsetup:
+        enable: true
+        name: cryptsetup
+      cryptsetup-initramfs:
+        enable: true
+        name: cryptsetup-initramfs
 
   github:
     enable: true


### PR DESCRIPTION
added crypsetup packages and option for having a encrypted persistent storage

here is an example for creating a encrypted persistent volume

```bash
cryptsetup luksFormat /dev/sdb
cryptsetup open /dev/sdb persistent_encrypted
mkfs.ext4 -L persistent /dev/mapper/persistent_encrypted
e2label /dev/mapper/persistent_encrypted persistence
mkdir /mnt/persistent_encrypted
mount /dev/mapper/persistent_encrypted /mnt/persistent_encrypted
echo "/home union" | sudo tee /mnt/persistent_encrypted/persistence.conf
umount /mnt/persistent_encrypted
cryptsetup luksClose /dev/mapper/persistent_encrypted
```

while booting a bootscreen will ask the user to enter his passphrase.

unencrypted persistent volumes are also working. 