### PR TITLE
firefox default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * default configuration for Gnome and Gnome shell extensions for easier accessibility
 * added mode indicator
 * added possibility to boot luks encrypted persistent volumes
+* default settings for firefox and chromium
 
 ## v0.2.0
 

--- a/debian-live/config/includes.chroot/etc/firefox-esr/custom.js
+++ b/debian-live/config/includes.chroot/etc/firefox-esr/custom.js
@@ -1,0 +1,129 @@
+// privacy notice
+pref("datareporting.policy.firstRunURL", "");
+
+// upgrade dialog
+pref("browser.startup.upgradeDialog.enabled", false);
+
+// setup dialog
+pref("browser.startup.homepage_override.mstone", "ignore");
+
+// recommend features as you browse
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
+
+// recommend extensions as you browse
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
+
+// recommendations in extension manager
+pref("extensions.htmlaboutaddons.recommendations.enabled", false);
+
+// notification about telemetry collected
+pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
+
+// sponsored links on new tab
+pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
+
+// prevent import bookmarks in toolbar
+pref("browser.bookmarks.addedImportButton", true);
+
+// show bookmarks always (default is only on new tabs => newtab)
+pref("browser.toolbars.bookmarks.visibility", "always");
+
+// settings from https://ffprofile.com
+pref("app.normandy.api_url", "");
+pref("app.normandy.enabled", false);
+pref("app.shield.optoutstudies.enabled", false);
+pref("app.update.auto", false);
+pref("beacon.enabled", false);
+pref("breakpad.reportURL", "");
+pref("browser.cache.offline.enable", false);
+pref("browser.crashReports.unsubmittedCheck.autoSubmit", false);
+pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
+pref("browser.crashReports.unsubmittedCheck.enabled", false);
+pref("browser.disableResetPrompt", true);
+pref("browser.newtab.preload", false);
+pref("browser.newtabpage.enabled", false);
+pref("browser.newtabpage.enhanced", false);
+pref("browser.newtabpage.introShown", true);
+pref("browser.safebrowsing.appRepURL", "");
+pref("browser.safebrowsing.blockedURIs.enabled", false);
+pref("browser.safebrowsing.downloads.enabled", false);
+pref("browser.safebrowsing.downloads.remote.enabled", false);
+pref("browser.safebrowsing.downloads.remote.url", "");
+pref("browser.safebrowsing.enabled", false);
+pref("browser.safebrowsing.malware.enabled", false);
+pref("browser.safebrowsing.phishing.enabled", false);
+pref("browser.selfsupport.url", "");
+pref("browser.send_pings", false);
+pref("browser.sessionstore.privacy_level", 0);
+pref("browser.tabs.crashReporting.sendReport", false);
+pref("browser.urlbar.groupLabels.enabled", false);
+pref("browser.urlbar.quicksuggest.enabled", false);
+pref("browser.urlbar.speculativeConnect.enabled", false);
+pref("datareporting.healthreport.service.enabled", false);
+pref("datareporting.healthreport.uploadEnabled", false);
+pref("datareporting.policy.dataSubmissionEnabled", false);
+pref("device.sensors.ambientLight.enabled", false);
+pref("device.sensors.enabled", false);
+pref("device.sensors.motion.enabled", false);
+pref("device.sensors.orientation.enabled", false);
+pref("device.sensors.proximity.enabled", false);
+pref("dom.battery.enabled", false);
+pref("dom.event.clipboardevents.enabled", false);
+pref("dom.private-attribution.submission.enabled", false);
+pref("dom.webaudio.enabled", false);
+pref("experiments.activeExperiment", false);
+pref("experiments.enabled", false);
+pref("experiments.manifest.uri", "");
+pref("experiments.supported", false);
+pref("extensions.getAddons.cache.enabled", false);
+pref("extensions.getAddons.showPane", false);
+pref("extensions.shield-recipe-client.api_url", "");
+pref("extensions.shield-recipe-client.enabled", false);
+pref("extensions.webservice.discoverURL", "");
+pref("media.autoplay.default", 0);
+pref("media.autoplay.enabled", true);
+pref("media.eme.enabled", false);
+pref("media.gmp-widevinecdm.enabled", false);
+pref("media.navigator.enabled", false);
+pref("media.peerconnection.enabled", false);
+pref("media.video_stats.enabled", false);
+pref("network.allow-experiments", false);
+pref("network.captive-portal-service.enabled", false);
+pref("network.cookie.cookieBehavior", 1);
+pref("network.dns.disablePrefetch", true);
+pref("network.dns.disablePrefetchFromHTTPS", true);
+pref("network.http.referer.spoofSource", true);
+pref("network.http.speculative-parallel-limit", 0);
+pref("network.predictor.enable-prefetch", false);
+pref("network.predictor.enabled", false);
+pref("network.prefetch-next", false);
+pref("network.trr.mode", 5);
+pref("privacy.donottrackheader.enabled", true);
+pref("privacy.donottrackheader.value", 1);
+pref("privacy.query_stripping", true);
+pref("privacy.trackingprotection.cryptomining.enabled", true);
+pref("privacy.trackingprotection.enabled", true);
+pref("privacy.trackingprotection.fingerprinting.enabled", true);
+pref("privacy.trackingprotection.pbmode.enabled", true);
+pref("privacy.usercontext.about_newtab_segregation.enabled", true);
+pref("security.ssl.disable_session_identifiers", true);
+pref("services.sync.prefs.sync.browser.newtabpage.activity-stream.showSponsoredTopSite", false);
+pref("signon.autofillForms", false);
+pref("toolkit.telemetry.archive.enabled", false);
+pref("toolkit.telemetry.bhrPing.enabled", false);
+pref("toolkit.telemetry.cachedClientID", "");
+pref("toolkit.telemetry.enabled", false);
+pref("toolkit.telemetry.firstShutdownPing.enabled", false);
+pref("toolkit.telemetry.hybridContent.enabled", false);
+pref("toolkit.telemetry.newProfilePing.enabled", false);
+pref("toolkit.telemetry.prompted", 2);
+pref("toolkit.telemetry.rejected", true);
+pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+pref("toolkit.telemetry.server", "");
+pref("toolkit.telemetry.shutdownPingSender.enabled", false);
+pref("toolkit.telemetry.unified", false);
+pref("toolkit.telemetry.unifiedIsOptIn", false);
+pref("toolkit.telemetry.updatePing.enabled", false);
+pref("webgl.disabled", true);
+pref("webgl.renderer-string-override", " ");
+pref("webgl.vendor-string-override", " ");

--- a/debian-live/config/includes.chroot/etc/skel/.mozilla/firefox/9o4epjc1.default-esr/bookmarks.html
+++ b/debian-live/config/includes.chroot/etc/skel/.mozilla/firefox/9o4epjc1.default-esr/bookmarks.html
@@ -1,0 +1,1 @@
+/usr/share/chromium/initial_bookmarks.html

--- a/debian-live/config/includes.chroot/etc/skel/.mozilla/firefox/profiles.ini
+++ b/debian-live/config/includes.chroot/etc/skel/.mozilla/firefox/profiles.ini
@@ -1,0 +1,11 @@
+[Profile0]
+Name=default-esr
+IsRelative=1
+Path=9o4epjc1.default-esr
+
+[General]
+Version=2
+
+[Install3B6073811A6ABF12]
+Default=9o4epjc1.default-esr
+Locked=1


### PR DESCRIPTION
- settings via pref file
- firefox stores bookmarks in a sqlite file, but imports from bookmark.html if there is no sqlite file
- so a symlink to the bookmarks for chromium allows to have only one definition for both browsers