### PR TITLE
move download of torbrowser to cache

### DIFF
--- a/debian-live/vendor/torbrowser/install.sh
+++ b/debian-live/vendor/torbrowser/install.sh
@@ -3,7 +3,12 @@ loginfo "fetchExternalPackages" "torbrowser package vendor package started"
 if [ "${DEBIAN_ARCH}" = "amd64" ]; then
     loginfo "fetchExternalPackages" "torbrowser package download started"
 
+    mkdir -p "${BUILD_DIR}"/cache/
     curl --continue-at - --silent --location https://dist.torproject.org/torbrowser/14.0.4/tor-browser-linux-x86_64-14.0.4.tar.xz --output "${BUILD_DIR}"/cache/tor-browser.tar.xz
+    if [ "$?" -ne 0 ]; then
+        logerror "fetchExternalPackages" "torbrowser package download failed"
+        exit 1
+    fi
     
     tar xf "${BUILD_DIR}"/cache/tor-browser.tar.xz -C ${BUILD_DIR}"/config/includes.chroot/opt/"
     chmod -R 755 ${BUILD_DIR}"/config/includes.chroot/opt/tor-browser"
@@ -20,7 +25,7 @@ if [ "${DEBIAN_ARCH}" = "amd64" ]; then
 Type=Application
 Name=Tor Browser
 GenericName=Web Browser
-Comment=Tor Browser  is +1 for privacy and −1 for mass surveillance
+Comment=Tor Browser is +1 for privacy and −1 for mass surveillance
 Categories=Network;WebBrowser;Security;
 Exec=sh -c "/opt/iksdp/bin/start_tor_browser.sh"
 Icon=/opt/tor-browser/Browser/browser/chrome/icons/default/default128.png

--- a/debian-live/vendor/torbrowser/install.sh
+++ b/debian-live/vendor/torbrowser/install.sh
@@ -3,9 +3,9 @@ loginfo "fetchExternalPackages" "torbrowser package vendor package started"
 if [ "${DEBIAN_ARCH}" = "amd64" ]; then
     loginfo "fetchExternalPackages" "torbrowser package download started"
 
-    curl --silent --location https://dist.torproject.org/torbrowser/14.0.4/tor-browser-linux-x86_64-14.0.4.tar.xz --output "tor-browser.tar.xz"
+    curl --continue-at - --silent --location https://dist.torproject.org/torbrowser/14.0.4/tor-browser-linux-x86_64-14.0.4.tar.xz --output "${BUILD_DIR}"/cache/tor-browser.tar.xz
     
-    tar xf tor-browser.tar.xz -C ${BUILD_DIR}"/config/includes.chroot/opt/"
+    tar xf "${BUILD_DIR}"/cache/tor-browser.tar.xz -C ${BUILD_DIR}"/config/includes.chroot/opt/"
     chmod -R 755 ${BUILD_DIR}"/config/includes.chroot/opt/tor-browser"
 
     SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
- archive was downloaded to the root directory of the repo
- use ${BUILD_DIR}/cache/ instead and don't download every time (`--continue-at`)