### PR TITLE
additional boot option for updating the image (toram)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 * added smbclient and nfs-common
 * added chromium to gnome favorites
 * updated to new version of package live-build (20250225)
-* added default documenation bookmark  
+* added default documentation bookmark
 * added iksdp desktop wallpaper
+* added boot option for updating the image (toram)
 
 ## v0.4.0
 

--- a/debian-live/config/bootloaders/grub-pc/grub.cfg
+++ b/debian-live/config/bootloaders/grub-pc/grub.cfg
@@ -5,8 +5,12 @@ menuentry "Live system (amd64)" --unrestricted --hotkey=l {
 	linux @KERNEL_LIVE@ @APPEND_LIVE@
 	initrd @INITRD_LIVE@
 }
-menuentry "Live system (amd64 fail-safe mode)" --unrestricted  {
+menuentry "Live system (amd64 fail-safe mode)" --unrestricted {
 	linux @KERNEL_LIVE@ boot=live components memtest noapic noapm nodma nomce nosmp nosplash vga=788
+	initrd @INITRD_LIVE@
+}
+menuentry "Live system (amd64 update)" {
+	linux @KERNEL_LIVE@ @APPEND_LIVE@ toram
 	initrd @INITRD_LIVE@
 }
 

--- a/debian-live/config/bootloaders/isolinux/live.cfg.in
+++ b/debian-live/config/bootloaders/isolinux/live.cfg.in
@@ -1,0 +1,18 @@
+label live-@FLAVOUR@
+	menu label ^Live system (@FLAVOUR@)
+	menu default
+	linux @LINUX@
+	initrd @INITRD@
+	append @APPEND_LIVE@
+
+label live-@FLAVOUR@-failsafe
+	menu label ^Live system (@FLAVOUR@ failsafe)
+	linux @LINUX@
+	initrd @INITRD@
+	append @APPEND_LIVE_FAILSAFE@
+
+label live-@FLAVOUR@-toram
+	menu label ^Live system (@FLAVOUR@ update)
+	linux @LINUX@
+	initrd @INITRD@
+	append @APPEND_LIVE@ toram


### PR DESCRIPTION
- boot completely to RAM without using the internal disk
- allows to update the image on the internal disk
- before updating, make sure the internal disk is really not used: `mount | grep nvme0n1`
- multiple options for updating:
    - direct download from the internet or local webserver: `curl --location http://iksdp.pfadfinderzentrum.org/debian-live-bookworm-0.5.0-20250313055721-amd64.hybrid.iso | dd of=/dev/nvme0n1`
    - mounting cifs or nfs share with the iso and writing it to disk with dd
    - using a seperate usb drive with the iso and writing it to disk with dd